### PR TITLE
fix(codeowners): requires asterisk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@garytryan
+* @garytryan

--- a/build/configs/webpack.dev.conf.js
+++ b/build/configs/webpack.dev.conf.js
@@ -2,12 +2,6 @@ const merge = require('webpack-merge')
 const base = require('./webpack.base.conf')
 
 module.exports = merge(base, {
-  externals: [
-    'vue',
-    'vue-types',
-    '@type/type-config',
-    '@tipe/tipe-interfaces',
-    '@tipe/tipe-constants'
-  ],
+  externals: ['vue', 'vue-types', '@type/type-config', '@tipe/tipe-constants'],
   devtool: 'cheap-module-eval-source-map'
 })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@tipe/tipe-config": "^1.0.0",
     "@tipe/tipe-constants": "^1.0.0",
-    "@tipe/tipe-interfaces": "^1.0.4-0",
     "autosize": "^4.0.2",
     "chokidar": "^2.0.4",
     "storybook": "^1.0.0",

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script>
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import vueTypes from 'vue-types'
 import TipeIcon from '../Icon'
 

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -37,7 +37,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeIcon from '../Icon'
 
 export default {

--- a/src/components/DocumentEditor/DocumentBlock/DocumentBlock.vue
+++ b/src/components/DocumentEditor/DocumentBlock/DocumentBlock.vue
@@ -33,7 +33,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeDocumentBlockValueInput from './DocumentBlockValueInput'
 import TipeDocumentBlockHeader from './DocumentBlockHeader'
 import TipeDocumentBlockMessage from './DocumentBlockMessage'

--- a/src/components/DocumentEditor/DocumentBlock/DocumentBlockHeader/DocumentBlockHeader.vue
+++ b/src/components/DocumentEditor/DocumentBlock/DocumentBlockHeader/DocumentBlockHeader.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeDocumentBlockNameInput from './DocumentBlockNameInput'
 import TipeDocumentBlockDescriptionInput from './DocumentBlockDescriptionInput'
 

--- a/src/components/DocumentEditor/DocumentBlock/DocumentBlockValueInput.vue
+++ b/src/components/DocumentEditor/DocumentBlock/DocumentBlockValueInput.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import { getBlockValueComponent } from '../helpers'
 import TipeSwitch from '@/components/Switch'
 import TipeNumberInput from '@/components/NumberInput'

--- a/src/components/DocumentEditor/DocumentBlockList/DocumentBlockList.vue
+++ b/src/components/DocumentEditor/DocumentBlockList/DocumentBlockList.vue
@@ -20,7 +20,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeDocumentBlock from '@/components/DocumentEditor/DocumentBlock'
 import TipeDocumentEmptyBlock from '@/components/DocumentEditor/DocumentBlock/DocumentEmptyBlock'
 

--- a/src/components/DocumentEditor/DocumentEditor.vue
+++ b/src/components/DocumentEditor/DocumentEditor.vue
@@ -14,7 +14,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeDocumentBlockList from './DocumentBlockList'
 import TipeDocumentNameInput from './DocumentNameInput'
 

--- a/src/components/Finder/FileIcon/FileIcon.vue
+++ b/src/components/Finder/FileIcon/FileIcon.vue
@@ -30,7 +30,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeFileIconRectangle from './FileIconRectangle'
 import TipeFileIconSquare from './FileIconSquare'
 import TipeFileIconDetails from './FileIconDetails'

--- a/src/components/Finder/FileIcon/FileIconDetails.vue
+++ b/src/components/Finder/FileIcon/FileIconDetails.vue
@@ -46,7 +46,7 @@
 <script>
 import vueTypes from 'vue-types'
 import TipeIcon from '@/components/Icon'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeFileIconDetails',

--- a/src/components/Finder/FileIcon/FileIconRectangle.vue
+++ b/src/components/Finder/FileIcon/FileIconRectangle.vue
@@ -28,7 +28,7 @@
 <script>
 import vueTypes from 'vue-types'
 import TipeIcon from '@/components/Icon'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeFileIconRectangle',

--- a/src/components/Finder/FileIcon/FileIconSquare.vue
+++ b/src/components/Finder/FileIcon/FileIconSquare.vue
@@ -29,7 +29,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeIcon from '@/components/Icon'
 import TipeCue from './CueIcon'
 

--- a/src/components/Finder/FinderContainer.vue
+++ b/src/components/Finder/FinderContainer.vue
@@ -13,7 +13,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TypeFinderViewer from './FinderViewer.vue'
 import TypeFinderEmpty from './FinderEmpty.vue'
 

--- a/src/components/Finder/FinderViewer.vue
+++ b/src/components/Finder/FinderViewer.vue
@@ -17,7 +17,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 import TipeFileIcon from './FileIcon'
 

--- a/src/components/NumberInput/NumberInput.vue
+++ b/src/components/NumberInput/NumberInput.vue
@@ -38,7 +38,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeIcon from '@/components/Icon'
 import { getPrecision } from '@/libs/float'
 

--- a/src/components/Radio/Radio.vue
+++ b/src/components/Radio/Radio.vue
@@ -30,7 +30,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeRadio',

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -7,7 +7,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 import TipeSelectUnderline from './SelectUnderline'
 import TipeSelectButton from './SelectButton'

--- a/src/components/Select/SelectButton.vue
+++ b/src/components/Select/SelectButton.vue
@@ -33,7 +33,7 @@
 <script>
 import vueTypes from 'vue-types'
 import ClickOutside from 'vue-click-outside'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeButton from '../Button'
 import TipeSelectDropdown from './SelectDropdown'
 import TipeNativeSelect from './NativeSelect'

--- a/src/components/Select/SelectUnderline.vue
+++ b/src/components/Select/SelectUnderline.vue
@@ -31,7 +31,7 @@
 <script>
 import vueTypes from 'vue-types'
 import ClickOutside from 'vue-click-outside'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeSelectDropdown from './SelectDropdown'
 import TipeNativeSelect from './NativeSelect'
 import {

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -24,7 +24,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeSidebarLink from './SidebarLink.vue'
 import TipeSidebarButton from './SidebarButton.vue'
 

--- a/src/components/Switch/Switch.vue
+++ b/src/components/Switch/Switch.vue
@@ -41,7 +41,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeSwitch',

--- a/src/components/Tabs/TabsMenu.vue
+++ b/src/components/Tabs/TabsMenu.vue
@@ -11,7 +11,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeTabsMenuButton from './TabsMenuButton'
 
 export default {

--- a/src/components/Tabs/TabsMenuButton.vue
+++ b/src/components/Tabs/TabsMenuButton.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeIcon from '@/components/Icon'
 
 export default {

--- a/src/components/TabsPanel/TabsPanel.vue
+++ b/src/components/TabsPanel/TabsPanel.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeTabsPanel',

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -17,7 +17,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeTextInput',

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -17,7 +17,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import autosize from 'autosize'
 
 export default {

--- a/src/interfaces/BlockOption.js
+++ b/src/interfaces/BlockOption.js
@@ -1,0 +1,8 @@
+import vueTypes from 'vue-types'
+
+export default {
+  type: vueTypes.string.def(''),
+  label: vueTypes.string.def(''),
+  icon: vueTypes.string.def(''),
+  description: vueTypes.string.def('')
+}

--- a/src/interfaces/CheckboxGroup.js
+++ b/src/interfaces/CheckboxGroup.js
@@ -1,0 +1,11 @@
+import vueTypes from 'vue-types'
+import checkboxOptions from './CheckboxOptions'
+
+export default {
+  name: vueTypes.string.def(''),
+  tabindex: vueTypes.number.def(0),
+  status: vueTypes.oneOf(['success', 'error', 'warning']),
+  waiting: vueTypes.bool.def(false),
+  disabled: vueTypes.bool.def(false),
+  options: vueTypes.arrayOf(checkboxOptions)
+}

--- a/src/interfaces/CheckboxOptions.js
+++ b/src/interfaces/CheckboxOptions.js
@@ -1,0 +1,8 @@
+import vueTypes from 'vue-types'
+import inputProps from './InputProps'
+
+export default {
+  label: vueTypes.string.def(''),
+  checked: vueTypes.bool.def(false),
+  ...inputProps
+}

--- a/src/interfaces/Document.js
+++ b/src/interfaces/Document.js
@@ -1,0 +1,8 @@
+import vueTypes from 'vue-types'
+import DocumentBlocks from './DocumentBlock'
+
+export default {
+  id: vueTypes.string.def(''),
+  name: vueTypes.string,
+  blocks: vueTypes.arrayOf(vueTypes.shape(DocumentBlocks))
+}

--- a/src/interfaces/DocumentBlock.js
+++ b/src/interfaces/DocumentBlock.js
@@ -1,0 +1,19 @@
+import vueTypes from 'vue-types'
+import DocumentBlockValidation from './DocumentBlockValidation'
+
+export default {
+  id: vueTypes.string.def(''),
+  type: vueTypes.string.def(''),
+  label: vueTypes.string.def(''),
+  name: vueTypes.string.def(''),
+  apiId: vueTypes.string.def(''),
+  value: vueTypes.any,
+  description: vueTypes.string.def(''),
+  status: vueTypes.oneOf(['success', 'error', 'warning', '']),
+  successMessage: vueTypes.string.def(''),
+  errorMessage: vueTypes.string.def(''),
+  warningMessage: vueTypes.string.def(''),
+  waiting: vueTypes.bool.def(false),
+  disabled: vueTypes.bool.def(false),
+  validation: vueTypes.shape(DocumentBlockValidation)
+}

--- a/src/interfaces/DocumentBlockValidation.js
+++ b/src/interfaces/DocumentBlockValidation.js
@@ -1,0 +1,5 @@
+import vueTypes from 'vue-types'
+
+export default {
+  required: vueTypes.bool.def(false)
+}

--- a/src/interfaces/File.js
+++ b/src/interfaces/File.js
@@ -1,0 +1,12 @@
+import vueTypes from 'vue-types'
+import UserShape from './User'
+
+export default {
+  id: vueTypes.string.def(''),
+  icon: vueTypes.string,
+  type: vueTypes.string,
+  label: vueTypes.string,
+  createdAt: vueTypes.integer,
+  updatedAt: vueTypes.integer,
+  createdBy: vueTypes.shape(UserShape)
+}

--- a/src/interfaces/Input.js
+++ b/src/interfaces/Input.js
@@ -1,0 +1,11 @@
+import vueTypes from 'vue-types'
+
+export default {
+  name: vueTypes.string.def(''),
+  value: vueTypes.any,
+  status: vueTypes.oneOf(['', 'success', 'error', 'warning']),
+  waiting: vueTypes.bool.def(false),
+  disabled: vueTypes.bool.def(false),
+  size: vueTypes.oneOf(['mini', 'small', 'medium', 'large']).def('medium'),
+  tabindex: vueTypes.number.def(0)
+}

--- a/src/interfaces/Link.js
+++ b/src/interfaces/Link.js
@@ -1,0 +1,6 @@
+import vueTypes from 'vue-types'
+
+export default {
+  label: vueTypes.string.def(''),
+  url: vueTypes.string.def('#')
+}

--- a/src/interfaces/NavLink.js
+++ b/src/interfaces/NavLink.js
@@ -1,0 +1,8 @@
+import vueTypes from 'vue-types'
+
+export default {
+  icon: vueTypes.string,
+  label: vueTypes.string,
+  url: vueTypes.string,
+  active: vueTypes.bool.def(false)
+}

--- a/src/interfaces/Roles.js
+++ b/src/interfaces/Roles.js
@@ -1,0 +1,6 @@
+import vueTypes from 'vue-types'
+
+export default {
+  label: vueTypes.string,
+  value: vueTypes.string
+}

--- a/src/interfaces/TabsMenuButton.js
+++ b/src/interfaces/TabsMenuButton.js
@@ -1,0 +1,7 @@
+import vueTypes from 'vue-types'
+
+export default {
+  icon: vueTypes.string.def(''),
+  label: vueTypes.string.def(''),
+  active: vueTypes.bool.def(false)
+}

--- a/src/interfaces/User.js
+++ b/src/interfaces/User.js
@@ -1,0 +1,14 @@
+import vueTypes from 'vue-types'
+import roleShape from './Roles'
+
+export default {
+  id: vueTypes.string,
+  profileImageUrl: vueTypes.string,
+  email: vueTypes.string,
+  firstName: vueTypes.string,
+  lastName: vueTypes.string,
+  role: vueTypes.shape(roleShape),
+  status: vueTypes.string,
+  createdAt: vueTypes.integer,
+  updatedAt: vueTypes.integer
+}

--- a/src/interfaces/index.js
+++ b/src/interfaces/index.js
@@ -1,0 +1,26 @@
+import user from './User'
+import blockOption from './BlockOption'
+import document from './Document'
+import documentBlock from './DocumentBlock'
+import documentBlockValidaton from './DocumentBlockValidation'
+import file from './File'
+import link from './Link'
+import navLink from './NavLink'
+import roles from './Roles'
+import input from './Input'
+import tabsMenuButton from './TabsMenuButton'
+
+
+export default {
+    user,
+    blockOption,
+    document,
+    documentBlock,
+    documentBlockValidaton,
+    file,
+    link,
+    navLink,
+    roles,
+    input,
+    tabsMenuButton
+}

--- a/src/layouts/Content/Content.vue
+++ b/src/layouts/Content/Content.vue
@@ -12,7 +12,7 @@
 <script>
 import vueTypes from 'vue-types'
 import TipeBreadcrumbs from '@/components/Breadcrumbs'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 
 export default {
   name: 'TipeContentLayout',

--- a/src/layouts/Dashboard/dashboard.vue
+++ b/src/layouts/Dashboard/dashboard.vue
@@ -22,7 +22,7 @@
 
 <script>
 import vueTypes from 'vue-types'
-import interfaces from '@tipe/tipe-interfaces'
+import interfaces from '@/interfaces'
 import TipeSidebar from '@/components/Sidebar'
 import TipeTopbar from '@/components/Topbar'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,14 +1147,6 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tipe/tipe-constants/-/tipe-constants-1.0.0.tgz#60e62ff777e4795bfe8070eb02849dbbb49b0f46"
 
-"@tipe/tipe-interfaces@^1.0.4-0":
-  version "1.0.4-0"
-  resolved "https://registry.yarnpkg.com/@tipe/tipe-interfaces/-/tipe-interfaces-1.0.4-0.tgz#a2d3b1abc5c31caf8249820771bf345f6b9a1a3a"
-  dependencies:
-    "@tipe/tipe-constants" "^1.0.0"
-    vue "^2.5.16"
-    vue-types "^1.3.2"
-
 "@tipe/tipe-test-utils@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@tipe/tipe-test-utils/-/tipe-test-utils-1.0.2.tgz#90277c55fbc850a9dbad7dc80259d3cd0bbf8e51"
@@ -13342,12 +13334,6 @@ vue-template-es2015-compiler@^1.5.3, vue-template-es2015-compiler@^1.6.0:
 vue-types@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/vue-types/-/vue-types-1.2.3.tgz#550777d60e459c9c4c54a5a0f0f97dc981bbab9f"
-  dependencies:
-    lodash.isplainobject "4.0.6"
-
-vue-types@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/vue-types/-/vue-types-1.3.2.tgz#d28b8f7ce2d74536025eaf6f1904fe9ec965c127"
   dependencies:
     lodash.isplainobject "4.0.6"
 


### PR DESCRIPTION
# **Rendering**

* [ ] Components render as designed - check storybook
* [ ] Storybook stories display all states

# **Behaviour**

* [ ] Components behave as designed - check storybook

# **Code Style**

* [ ] The file has less than 200 line.
* [ ] All functions are less than 25 lines long, and do **one** thing.
* [ ] Variable names are descriptive (says what it is).
* [ ] Components are only concerned with presentation.
  * methods - do not transform data
  * computed - only transforms data for presentation purposes, and logic is simple and concise
  * data - only contains properties directly related to presentation logic
* [ ] Tipe components are prefixed 'Tipe', exp 'TipeButton'
* [ ] Tipe components are refrenced in <templates> with kebab-case, exp 'tipe-button'
* [ ] Component name is CamelCase, exp { name: 'TipeButton' }
* [ ] Components have `data-tipe-ui="$options.name"` on the root element.

# Tests

**<template>**

* [ ] tests `data-tipe-ui` on root is as expected
* [ ] snapshot test - should render to string

**:props**

* [ ] all props are tested

**@events**

* [ ] all events are tested

# README

**:props**

* [ ] all props are clearly described and easy to understand

**@events**

* [ ] all events are clearly described and easy to understand
